### PR TITLE
Use X or Xwayland instead of Wayland

### DIFF
--- a/utm_no/__main__.py
+++ b/utm_no/__main__.py
@@ -8,6 +8,13 @@ import logging
 
 from . import url_handler
 
+gi.require_version('Gdk', '3.0')
+import gi.module
+
+# require X or Xwayland, since we haven't worked out how to access the
+# clipboard under Wayland yet:
+gi.module.get_introspection_module('Gdk').set_allowed_backends('x11')
+
 gi.require_version('Gtk', '3.0')
 from gi.repository import GObject, Gtk, GLib, GdkPixbuf, Gdk, Gio
 


### PR DESCRIPTION
The code is broken when run under Wayland, so it's better to make the code run under Xwayland or X.

This fixes https://github.com/stuartlangridge/utm_no/issues/6